### PR TITLE
fix(echo): remove echo, use bytes.NewBufferString, fixes #3

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -91,6 +91,18 @@ dns_servers_eth0=(
 	if config.Coreos.Units[2].Name != "50-eth0.network" {
 		t.Fatalf("got %v, expected %v", config.Coreos.Units[2].Name, "50-eth0.network")
 	}
+	expected := `[Match]
+Name=eth0
+
+[Network]
+DNS=173.203.4.9
+DNS=173.203.4.8
+Address=23.253.212.214/24
+Gateway=23.253.212.1
+`
+	if config.Coreos.Units[2].Content != expected {
+		t.Fatalf("got\t%v, expected\t%v", config.Coreos.Units[2].Content, expected)
+	}
 }
 func TestHostname(t *testing.T) {
 	hostname := `# Set to the hostname of this machine


### PR DESCRIPTION
@philips took a swing at this. The only problem is that I keep getting transient failures. Do you have any idea what I might be doing wrong?

```
Alexs-MacBook-Air-3:nova-agent-watcher polvi$ go test -v .
=== RUN TestSSH
--- PASS: TestSSH (0.00 seconds)
=== RUN TestNet
--- PASS: TestNet (0.10 seconds)
=== RUN TestHostname
--- PASS: TestHostname (0.00 seconds)
=== RUN TestShadow
--- PASS: TestShadow (0.00 seconds)
PASS
ok      github.com/coreos/nova-agent-watcher    0.144s
Alexs-MacBook-Air-3:nova-agent-watcher polvi$ go test -v .
=== RUN TestSSH
--- PASS: TestSSH (0.00 seconds)
=== RUN TestNet
--- PASS: TestNet (0.09 seconds)
=== RUN TestHostname
--- PASS: TestHostname (0.00 seconds)
=== RUN TestShadow
--- PASS: TestShadow (0.00 seconds)
PASS
ok      github.com/coreos/nova-agent-watcher    0.131s
Alexs-MacBook-Air-3:nova-agent-watcher polvi$ go test -v .
=== RUN TestSSH
--- PASS: TestSSH (0.00 seconds)
=== RUN TestNet
2014/03/16 21:40:21 error: script wait failed write |1: broken pipe
--- FAIL: TestNet (0.01 seconds)
    main_test.go:80: write |1: broken pipe
=== RUN TestHostname
--- PASS: TestHostname (0.00 seconds)
=== RUN TestShadow
--- PASS: TestShadow (0.00 seconds)
FAIL
exit status 1
FAIL    github.com/coreos/nova-agent-watcher    0.047s
```
